### PR TITLE
Fixes base representer

### DIFF
--- a/igdb-api.gemspec
+++ b/igdb-api.gemspec
@@ -21,9 +21,9 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency 'bundler', '~> 1.9'
   spec.add_development_dependency 'rake', '~> 10.0'
-  spec.add_development_dependency 'rspec', '~> 3.3.0'
-  spec.add_development_dependency 'vcr', '~> 2.9.3'
-  spec.add_development_dependency 'webmock', '~> 1.21.0'
+  spec.add_development_dependency 'rspec', '~> 3.7.0'
+  spec.add_development_dependency 'vcr', '~> 3.0.3'
+  spec.add_development_dependency 'webmock', '~> 3.1.0'
   spec.add_development_dependency 'simplecov'
   spec.add_development_dependency 'codeclimate-test-reporter', '~> 1.0.0'
   spec.add_development_dependency 'pry'

--- a/lib/igdb/representers/base_representer.rb
+++ b/lib/igdb/representers/base_representer.rb
@@ -1,14 +1,12 @@
 module Igdb::BaseRepresenter
-  include Representable::JSON
 
   def self.included(base)
     base.include Representable::JSON
+    base.property :id
+    base.property :name
+    base.property :slug
+    base.property :url
+    base.property :created_at
+    base.property :updated_at
   end
-
-  property :id
-  property :name
-  property :slug
-  property :url
-  property :created_at
-  property :updated_at
 end

--- a/lib/igdb/representers/company_representer.rb
+++ b/lib/igdb/representers/company_representer.rb
@@ -1,7 +1,7 @@
 module Igdb::CompanyRepresenter
   include Igdb::BaseRepresenter
 
-  property :logo, extend: Igdb::ImageRepresenter, class: OpenStruct 
+  property :logo, extend: Igdb::ImageRepresenter, class: OpenStruct
   property :description
   property :country
   property :website

--- a/spec/lib/igdb/models/company_spec.rb
+++ b/spec/lib/igdb/models/company_spec.rb
@@ -9,32 +9,41 @@ describe Igdb::Company do
 
   describe "public class methods" do
     context "responds to its methods" do
+      it { expect(subject).to respond_to(:name) }
       it { expect(subject).to respond_to(:count) }
       it { expect(subject).to respond_to(:find) }
     end
 
+
+
+
     context "executes methods correctly" do
       context "self.count" do
-        let(:response) { 
-          VCR.use_cassette("companies/count") { 
-            subject.count 
-          } 
+        let(:response) {
+          VCR.use_cassette("companies/count") {
+            subject.count
+          }
         }
 
         it "returns the number of companies in the database" do
-          expect(response).to eq(11_648)
+          expect(response).to eq(13323)
         end
       end
 
       context "self.find" do
-        let(:response) { 
-          VCR.use_cassette("companies/find") { 
-            subject.find(2_000) 
-          } 
+        let(:response) {
+          VCR.use_cassette("companies/find") {
+            subject.find(2_000)
+          }
+
         }
 
         it "returns a company" do
           expect(response).to be_a Igdb::Company
+        end
+
+        it "returns a company name" do
+          expect(response.name).to eq "Cat Daddy Games"
         end
       end
     end

--- a/spec/lib/igdb/models/game_spec.rb
+++ b/spec/lib/igdb/models/game_spec.rb
@@ -17,34 +17,38 @@ describe Igdb::Game do
 
     context "executes methods correctly" do
       context "self.count" do
-        let(:response) { 
-          VCR.use_cassette("game/count") { 
-            subject.count 
-          } 
+        let(:response) {
+          VCR.use_cassette("game/count") {
+            subject.count
+          }
         }
 
         it "returns the number of games in the database" do
-          expect(response).to eq(26_091)
+          expect(response).to eq(73255)
         end
       end
 
       context "self.find" do
-        let(:response) { 
-          VCR.use_cassette("game/find") { 
-            subject.find(2000) 
-          } 
+        let(:response) {
+          VCR.use_cassette("game/find") {
+            subject.find(2000)
+          }
         }
 
         it "returns a game" do
           expect(response).to be_a Igdb::Game
         end
+
+        it "returns a game name" do
+          expect(response.name).to eq "Postal"
+        end
       end
 
       context "self.search" do
-        let(:response) { 
-          VCR.use_cassette("game/search") { 
-            subject.search(query: "batman") 
-          } 
+        let(:response) {
+          VCR.use_cassette("game/search") {
+            subject.search(query: "batman")
+          }
         }
 
         it "returns a group of game results" do
@@ -55,22 +59,22 @@ describe Igdb::Game do
       end
 
       context "self.all" do
-        let(:response) { 
-          VCR.use_cassette("game/all") { 
-            subject.all 
-          } 
-        }
-        
-        let(:response_with_limit) { 
-          VCR.use_cassette("game/all-limit") { 
-            subject.all(limit: 5) 
-          } 
+        let(:response) {
+          VCR.use_cassette("game/all") {
+            subject.all
+          }
         }
 
-        let(:response_with_limit_and_offset) { 
+        let(:response_with_limit) {
+          VCR.use_cassette("game/all-limit") {
+            subject.all(limit: 5)
+          }
+        }
+
+        let(:response_with_limit_and_offset) {
           VCR.use_cassette("game/all-limit-and-offset") {
-            subject.all(limit: 5, offset: 2) 
-          } 
+            subject.all(limit: 5, offset: 2)
+          }
         }
 
         it "returns a list of games" do

--- a/spec/lib/igdb/models/people_spec.rb
+++ b/spec/lib/igdb/models/people_spec.rb
@@ -17,33 +17,37 @@ describe Igdb::Person do
 
     context "executes methods correctly" do
       context "self.count" do
-        let(:response) { 
-          VCR.use_cassette("people/count") { 
-            subject.count 
-          } 
+        let(:response) {
+          VCR.use_cassette("people/count") {
+            subject.count
+          }
         }
 
         it "returns the number of games in the database" do
-          expect(response).to eq(135_074)
+          expect(response).to eq(141385)
         end
       end
 
       context "self.find" do
-        let(:response) { 
-          VCR.use_cassette("people/find") { 
-            subject.find(2_000) 
-          } 
+        let(:response) {
+          VCR.use_cassette("people/find") {
+            subject.find(2_000)
+          }
         }
 
         it "returns a person" do
           expect(response).to be_a Igdb::Person
         end
+
+        it "returns a person name" do
+          expect(response.name).to eq "Laura Battistuzzi"
+        end
       end
 
       context "self.search" do
-        let(:response) { 
-          VCR.use_cassette("people/search") { 
-            subject.search(query: "batman") 
+        let(:response) {
+          VCR.use_cassette("people/search") {
+            subject.search(query: "batman")
           }
         }
 
@@ -55,21 +59,21 @@ describe Igdb::Person do
       end
 
       context "self.all" do
-        let(:response) { 
-          VCR.use_cassette("people/all") { 
-            subject.all 
-          } 
-        }
-        
-        let(:response_with_limit) { 
-          VCR.use_cassette("people/all-limit") { 
-            subject.all(limit: 5) 
-          } 
+        let(:response) {
+          VCR.use_cassette("people/all") {
+            subject.all
+          }
         }
 
-        let(:response_with_limit_and_offset) { 
-          VCR.use_cassette("people/all-limit-and-offset") { 
-            subject.all(limit: 5, offset: 2) 
+        let(:response_with_limit) {
+          VCR.use_cassette("people/all-limit") {
+            subject.all(limit: 5)
+          }
+        }
+
+        let(:response_with_limit_and_offset) {
+          VCR.use_cassette("people/all-limit-and-offset") {
+            subject.all(limit: 5, offset: 2)
           }
         }
 


### PR DESCRIPTION
Base representer properties weren't accessable because the module inclusion was incorrect.
Base representer adds properties to the module that includes it, not to itself.